### PR TITLE
fix grammar of hit message

### DIFF
--- a/src/Game/Collision.elm
+++ b/src/Game/Collision.elm
@@ -145,7 +145,7 @@ defend monster ({ hero, seed } as model) =
             { hero | stats = heroStats' }
 
         newMsg =
-            newHitMessage (Monster.name monster) "you" (toString damage)
+            newHitMessage ("The " ++ Monster.name monster) "you" (toString damage)
     in
         { model | hero = hero', seed = seed', messages = newMsg :: model.messages }
 

--- a/src/Game/Collision.elm
+++ b/src/Game/Collision.elm
@@ -130,7 +130,7 @@ attack monster ({ hero, seed, monsters } as model) =
                 monster' :: monstersWithoutMonster
 
         newMsg =
-            newHitMessage "You" (Monster.name monster) (toString damage)
+            newHitMessage "You" ("the " ++ Monster.name monster) (toString damage)
     in
         { model | monsters = monsters', messages = newMsg :: model.messages }
 
@@ -152,7 +152,7 @@ defend monster ({ hero, seed } as model) =
 
 newHitMessage : String -> String -> String -> String
 newHitMessage attacker defender damage =
-    attacker ++ " hit the " ++ defender ++ " for " ++ damage ++ " damage!"
+    attacker ++ " hit " ++ defender ++ " for " ++ damage ++ " damage!"
 
 
 


### PR DESCRIPTION
There were messages like this: "Hobgoblin hit the you for 6 damage!"
I removed the extra "the" when you get attacked.
