### PR TITLE
new viewport algorithm: center character on screen when reaching the edges

### DIFF
--- a/src/Game/Data.elm
+++ b/src/Game/Data.elm
@@ -26,6 +26,8 @@ type alias Model =
     , seed : Random.Seed
     , windowSize : Window.Size
     , messages : List String
+    , viewportX: Int
+    , viewportY: Int
     }
 
 

--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -105,7 +105,7 @@ update msg model =
                 model' =
                     Game.Collision.tryMoveHero dir model
 
-                (viewportX, viewportY) = updateViewportOffset model model'
+                (viewportX, viewportY) = updateViewportOffset model.hero.position model'
 
                 model'' = { model' | viewportX = viewportX, viewportY = viewportY }
 
@@ -140,19 +140,19 @@ update msg model =
             ( { model | windowSize = size }, Cmd.none )
 
 
-updateViewportOffset : Model -> Model -> Vector
-updateViewportOffset prevModel ({ windowSize, viewportX, viewportY, maps } as model) =
+updateViewportOffset : Vector -> Model -> Vector
+updateViewportOffset prevPosition ({ windowSize, viewportX, viewportY, maps } as model) =
     let
         tileSize = 32
 
         ( prevX, prevY ) =
-            Vector.scale tileSize prevModel.hero.position
+            Vector.scale tileSize prevPosition
 
         ( x, y ) =
             Vector.scale tileSize model.hero.position
 
         ( xOff, yOff ) =
-            ( windowSize.width // tileSize * 16, windowSize.height // tileSize * 16 )
+            ( windowSize.width // 2, windowSize.height // 2 )
 
         tolerance = tileSize * 4
 

--- a/src/Game/Maps.elm
+++ b/src/Game/Maps.elm
@@ -10,7 +10,7 @@ module Game.Maps
         , draw
         , fromTiles
         , currentAreaMap
-        , currentAreaSize
+        , mapSize
         , getASCIIMap
         , getBuildings
         , getTile
@@ -39,7 +39,6 @@ import Html exposing (..)
 import Dict exposing (..)
 import Random exposing (..)
 import Dungeon.Rooms.Config as Config exposing (..)
-import Window exposing (Size)
 
 
 type Maps
@@ -55,6 +54,10 @@ type alias Model =
 
 type alias Map =
     Dict Vector Tile
+
+
+type alias Dimension =
+    Vector
 
 
 type Msg
@@ -189,16 +192,15 @@ currentAreaMap (A model) =
                 Dict.empty
 
 
-{-| Get the width and height of the map for the current area
+{-| Get the width and height of a map
 -}
-currentAreaSize: Maps -> Size
-currentAreaSize (A model) =
+mapSize: Map -> Dimension
+mapSize map =
     let
-        map = currentAreaMap (A model)
         positions = Dict.keys map
         (maxX, maxY) = List.foldr (\(a,b) (c,d) -> (max a c, max b d)) (0,0) positions
     in
-        { width = maxX + 1, height = maxY + 1 }
+        ( maxX + 1, maxY + 1 )
 
 
 {-| Get the buildings in the current area

--- a/src/Game/Maps.elm
+++ b/src/Game/Maps.elm
@@ -10,6 +10,7 @@ module Game.Maps
         , draw
         , fromTiles
         , currentAreaMap
+        , currentAreaSize
         , getASCIIMap
         , getBuildings
         , getTile
@@ -38,6 +39,7 @@ import Html exposing (..)
 import Dict exposing (..)
 import Random exposing (..)
 import Dungeon.Rooms.Config as Config exposing (..)
+import Window exposing (Size)
 
 
 type Maps
@@ -185,6 +187,18 @@ currentAreaMap (A model) =
 
             Nothing ->
                 Dict.empty
+
+
+{-| Get the width and height of the map for the current area
+-}
+currentAreaSize: Maps -> Size
+currentAreaSize (A model) =
+    let
+        map = currentAreaMap (A model)
+        positions = Dict.keys map
+        (maxX, maxY) = List.foldr (\(a,b) (c,d) -> (max a c, max b d)) (0,0) positions
+    in
+        { width = maxX + 1, height = maxY + 1 }
 
 
 {-| Get the buildings in the current area


### PR DESCRIPTION
I've changed the viewport algorithm, my aim was to be closer to the original game. Comments are welcome. 

I feel that the new `updateViewportOffset` function can be refactored into several little functions.

Screencast:

![out](https://cloud.githubusercontent.com/assets/1175986/19406786/3cde79a0-9264-11e6-825d-4f8f7930cc6d.gif)
