### PR TITLE
laggy movement caused by FOV

### DIFF
--- a/src/Level.elm
+++ b/src/Level.elm
@@ -28,6 +28,7 @@ import Types exposing (..)
 import Utils.BresenhamLine as BresenhamLine
 import Utils.Vector as Vector exposing (Vector)
 import Utils.FieldOfView
+import Set
 
 
 type alias Map =
@@ -195,14 +196,11 @@ updateFOV : Vector -> Level -> Level
 updateFOV heroPosition ({ map, rooms, corridors, monsters } as level) =
     let
         newMap =
-            Utils.FieldOfView.fov heroPosition (isSeeThrough level) (Vector.neighbours)
+            Utils.FieldOfView.find heroPosition (isSeeThrough level) (Vector.neighbours >> Set.fromList)
+                |> Set.toList
                 |> List.foldl addToMapAsVisibleTile map
 
-        --                level
-        --                |> unexploredTiles
-        --                |> List.filter (\tile -> lineOfSight heroPosition tile.position level)
-        --                |> List.map (Tile.setVisibility Known)
-        addToMapAsVisibleTile: Vector -> Map -> Map
+        addToMapAsVisibleTile : Vector -> Map -> Map
         addToMapAsVisibleTile tilePosition map =
             tilePosition
                 |> getTile map

--- a/src/Level.elm
+++ b/src/Level.elm
@@ -27,6 +27,7 @@ import Tile.Types
 import Types exposing (..)
 import Utils.BresenhamLine as BresenhamLine
 import Utils.Vector as Vector exposing (Vector)
+import Utils.FieldOfView
 
 
 type alias Map =
@@ -157,49 +158,57 @@ floors { map } =
 ------
 
 
-lineOfSight : Vector -> Vector -> Level -> Bool
-lineOfSight a b ({ map, rooms } as level) =
-    let
-        roomLightSource tile =
-            roomAtPosition tile.position rooms
-                |> Maybe.map .lightSource
-                |> Maybe.withDefault Dark
-
-        isSeeThroughOrEitherEndpoints tile =
-            ((not tile.solid) && (tile.type_ /= Tile.Types.DoorClosed) && (roomLightSource tile /= Dark))
-                || (tile.position == a)
-                || (tile.position == b)
-                || (Vector.adjacent a b)
-    in
-        BresenhamLine.line a b
-            |> List.map (\point -> Dict.get point map)
-            |> List.map (Maybe.map isSeeThroughOrEitherEndpoints)
-            |> List.map (Maybe.withDefault False)
-            |> List.all identity
-
-
 calculateMonsterVisibility : Monster -> Vector -> Level -> Monster
 calculateMonsterVisibility monster heroPosition ({ map } as level) =
-    if lineOfSight monster.position heroPosition level then
+    if Utils.FieldOfView.los monster.position heroPosition (isSeeThrough level) then
         { monster | visible = LineOfSight }
     else
         monster
 
 
+roomAndDark : List Room -> Vector -> Bool
+roomAndDark rooms position =
+    roomAtPosition position rooms
+        |> Maybe.map .lightSource
+        |> Maybe.withDefault Dark
+        |> (==) Dark
+
+
+isSeeThrough : Level -> Vector -> Bool
+isSeeThrough { map, rooms } target =
+    let
+        notSolid =
+            .solid >> not
+
+        notClosedDoor =
+            .type_ >> ((/=) Tile.Types.DoorClosed)
+
+        notDarkRoom =
+            roomAndDark rooms >> not
+    in
+        getTile map target
+            |> Maybe.map (\tile -> (notSolid tile && notClosedDoor tile && notDarkRoom target))
+            |> Maybe.withDefault False
+
+
 updateFOV : Vector -> Level -> Level
 updateFOV heroPosition ({ map, rooms, corridors, monsters } as level) =
     let
-        newExploredTiles =
-            level
-                |> unexploredTiles
-                |> List.filter (\tile -> lineOfSight heroPosition tile.position level)
-                |> List.map (Tile.setVisibility Known)
-
-        addToMap tile map =
-            Dict.insert tile.position tile map
-
         newMap =
-            List.foldl addToMap map newExploredTiles
+            Utils.FieldOfView.fov heroPosition (isSeeThrough level) (Vector.neighbours)
+                |> List.foldl addToMapAsVisibleTile map
+
+        --                level
+        --                |> unexploredTiles
+        --                |> List.filter (\tile -> lineOfSight heroPosition tile.position level)
+        --                |> List.map (Tile.setVisibility Known)
+        addToMapAsVisibleTile: Vector -> Map -> Map
+        addToMapAsVisibleTile tilePosition map =
+            tilePosition
+                |> getTile map
+                |> Maybe.map (Tile.setVisibility Known)
+                |> Maybe.map (\x -> Dict.insert x.position x map)
+                |> Maybe.withDefault map
 
         newMonsters =
             monsters

--- a/src/Level.elm
+++ b/src/Level.elm
@@ -215,14 +215,6 @@ updateFOV heroPosition ({ map, rooms, corridors, monsters } as level) =
         { level | map = newMap, monsters = newMonsters }
 
 
-unexploredTiles : Level -> List Tile
-unexploredTiles { map } =
-    map
-        |> Dict.toList
-        |> List.map Tuple.second
-        |> List.filter (.visible >> (==) Hidden)
-
-
 {-| Returns a tuple (N, E, S, W) of tiles neighbouring the center tile.
 -}
 getTile : Map -> Vector -> Maybe Tile

--- a/src/Utils/FieldOfView.elm
+++ b/src/Utils/FieldOfView.elm
@@ -1,6 +1,6 @@
-module Utils.FieldOfView exposing (fov)
+module Utils.FieldOfView exposing (fov, los)
 
-import Utils.Vector exposing (Vector)
+import Utils.Vector as Vector exposing (Vector)
 import EveryDict exposing (EveryDict)
 import Utils.BresenhamLine as BresenhamLine
 
@@ -10,40 +10,30 @@ type alias Map =
 
 
 fov : Vector -> (Vector -> Bool) -> (Vector -> List Vector) -> List Vector
-fov source isSolid neighbours =
-    fov_ source source isSolid neighbours
+fov source isSeeThrough neighbours =
+    fov_ source source isSeeThrough neighbours
 
 
 fov_ : Vector -> Vector -> (Vector -> Bool) -> (Vector -> List Vector) -> List Vector
-fov_ source current isSolid neighbours =
+fov_ source current isSeeThrough neighbours =
     let
         inSight target =
-            lineOfSight source target isSolid
+            los source target isSeeThrough
 
         inView revealedPosition =
-            fov_ source revealedPosition isSolid neighbours
+            fov_ source revealedPosition isSeeThrough neighbours
     in
         neighbours current
-            |> List.map (inSight >> inView)
+            |> List.filter inSight
+            |> List.map inView
             |> List.concat
 
 
-lineOfSight : Vector -> Vector -> (Vector -> Bool) -> Bool
-lineOfSight a b isSolid ({ map, rooms } as level) =
+los : Vector -> Vector -> (Vector -> Bool) -> Bool
+los a b isSeeThrough =
     let
-        roomLightSource tile =
-            roomAtPosition tile.position rooms
-                |> Maybe.map .lightSource
-                |> Maybe.withDefault Dark
-
-        isSeeThroughOrEitherEndpoints tile =
-            ((not tile.solid) && (tile.type_ /= Tile.Types.DoorClosed) && (roomLightSource tile /= Dark))
-                || (tile.position == a)
-                || (tile.position == b)
-                || (Vector.adjacent a b)
+        isSeeThroughOrEitherEndpoints point =
+            (isSeeThrough point) || (point == a) || (point == b) || Vector.adjacent a b
     in
         BresenhamLine.line a b
-            |> List.map (\point -> Dict.get point map)
-            |> List.map (Maybe.map isSeeThroughOrEitherEndpoints)
-            |> List.map (Maybe.withDefault False)
-            |> List.all identity
+            |> List.all isSeeThroughOrEitherEndpoints

--- a/src/Utils/FieldOfView.elm
+++ b/src/Utils/FieldOfView.elm
@@ -1,32 +1,72 @@
-module Utils.FieldOfView exposing (fov, los)
+module Utils.FieldOfView exposing (find, los)
+
+{-| For any given graph, will span out from the source point, collecting visible nodes
+    until there are no more nodes to collect.
+-}
 
 import Utils.Vector as Vector exposing (Vector)
 import EveryDict exposing (EveryDict)
 import Utils.BresenhamLine as BresenhamLine
+import Set exposing (Set)
 
 
 type alias Map =
     EveryDict Vector Bool
 
 
-fov : Vector -> (Vector -> Bool) -> (Vector -> List Vector) -> List Vector
-fov source isSeeThrough neighbours =
-    fov_ source source isSeeThrough neighbours
+{-| The algorithm starts off with the source node which is unexplored and adds unexplored
+ neighbours that are not part of the explored set. Each time it explores a node, it adds
+ the node to the explored set and if visible, then to the visible set.
+ Once there are no more unexplored nodes, it returns the visible set.
+-}
+type alias FieldOfView comparable =
+    { unexplored : List comparable
+    , explored : Set comparable
+    , visible : Set comparable
+    , isSeeThrough : comparable -> Bool
+    , getNeighbours : comparable -> Set comparable
+    }
 
 
-fov_ : Vector -> Vector -> (Vector -> Bool) -> (Vector -> List Vector) -> List Vector
-fov_ source current isSeeThrough neighbours =
+find : Vector -> (Vector -> Bool) -> (Vector -> Set Vector) -> Set Vector
+find source isSeeThrough neighbours =
     let
-        inSight target =
-            los source target isSeeThrough
-
-        inView revealedPosition =
-            fov_ source revealedPosition isSeeThrough neighbours
+        fov =
+            FieldOfView [ source ] Set.empty Set.empty isSeeThrough neighbours
     in
-        neighbours current
-            |> List.filter inSight
-            |> List.map inView
-            |> List.concat
+        find_ source fov
+            |> .visible
+
+
+find_ : Vector -> FieldOfView Vector -> FieldOfView Vector
+find_ source ({ unexplored, explored, visible, isSeeThrough, getNeighbours } as fov) =
+    let
+        addNeighbours x fov =
+            let
+                neighbours =
+                    getNeighbours x
+            in
+                { fov | unexplored = (Set.diff neighbours fov.explored |> Set.toList) ++ fov.unexplored }
+    in
+        case unexplored of
+            [] ->
+                fov
+
+            x :: xs ->
+                if los source x isSeeThrough then
+                    { fov
+                        | unexplored = xs
+                        , explored = Set.insert x explored
+                        , visible = Set.insert x visible
+                    }
+                        |> addNeighbours x
+                        |> find_ source
+                else
+                    find_ source
+                        { fov
+                            | unexplored = xs
+                            , explored = Set.insert x explored
+                        }
 
 
 los : Vector -> Vector -> (Vector -> Bool) -> Bool

--- a/src/Utils/FieldOfView.elm
+++ b/src/Utils/FieldOfView.elm
@@ -1,0 +1,49 @@
+module Utils.FieldOfView exposing (fov)
+
+import Utils.Vector exposing (Vector)
+import EveryDict exposing (EveryDict)
+import Utils.BresenhamLine as BresenhamLine
+
+
+type alias Map =
+    EveryDict Vector Bool
+
+
+fov : Vector -> (Vector -> Bool) -> (Vector -> List Vector) -> List Vector
+fov source isSolid neighbours =
+    fov_ source source isSolid neighbours
+
+
+fov_ : Vector -> Vector -> (Vector -> Bool) -> (Vector -> List Vector) -> List Vector
+fov_ source current isSolid neighbours =
+    let
+        inSight target =
+            lineOfSight source target isSolid
+
+        inView revealedPosition =
+            fov_ source revealedPosition isSolid neighbours
+    in
+        neighbours current
+            |> List.map (inSight >> inView)
+            |> List.concat
+
+
+lineOfSight : Vector -> Vector -> (Vector -> Bool) -> Bool
+lineOfSight a b isSolid ({ map, rooms } as level) =
+    let
+        roomLightSource tile =
+            roomAtPosition tile.position rooms
+                |> Maybe.map .lightSource
+                |> Maybe.withDefault Dark
+
+        isSeeThroughOrEitherEndpoints tile =
+            ((not tile.solid) && (tile.type_ /= Tile.Types.DoorClosed) && (roomLightSource tile /= Dark))
+                || (tile.position == a)
+                || (tile.position == b)
+                || (Vector.adjacent a b)
+    in
+        BresenhamLine.line a b
+            |> List.map (\point -> Dict.get point map)
+            |> List.map (Maybe.map isSeeThroughOrEitherEndpoints)
+            |> List.map (Maybe.withDefault False)
+            |> List.all identity


### PR DESCRIPTION
The current FOV algo takes every unexplored tile and checked for line of sight. So when you just enter a dungeon, this is checking 150x150 (22500) tiles for visibility per move. Not good.